### PR TITLE
Add order field and reordering logic for checklist item templates

### DIFF
--- a/docs/checklist-item-ordering.md
+++ b/docs/checklist-item-ordering.md
@@ -1,0 +1,127 @@
+# Checklist Item Ordering Feature
+
+## Overview
+
+The checklist item ordering feature allows for manual ordering of checklist item templates and instances. This ordering is used to determine the display order of checklist items in the UI, providing a more intuitive and customizable user experience.
+
+## Implementation Details
+
+### Checklist Item Templates
+
+Checklist item templates now include an `order` field, which is an integer that determines the display order. Lower values are displayed first. The default value is `0`.
+
+```json
+{
+  "_id": "60d21bbfe3d5d533d9fc1e4c",
+  "workflowTemplateId": "60d21bbfe3d5d533d9fc1e4d",
+  "name": "Upload Model Documentation",
+  "description": "Upload documentation for the AI model",
+  "type": "document",
+  "dependencies_requires": [],
+  "metadata": {
+    "requiredEvidence": true,
+    "approver": "manager"
+  },
+  "order": 1,
+  "createdAt": "2024-03-20T10:00:00.000Z",
+  "updatedAt": "2024-03-20T10:00:00.000Z"
+}
+```
+
+### Checklist Item Instances
+
+When a project is created, the `order` field from each checklist item template is copied to the corresponding checklist item instance. This ensures that the ordering is preserved when checklist items are instantiated for a project.
+
+```json
+{
+  "_id": "60d21bbfe3d5d533d9fc1e4c",
+  "workflowInstanceId": "60d21bbfe3d5d533d9fc1e4d",
+  "checklistItemTemplateId": "60d21bbfe3d5d533d9fc1e4e",
+  "name": "Upload Model Documentation",
+  "description": "Upload documentation for the AI model",
+  "type": "document",
+  "status": "incomplete",
+  "dependencies_requires": [],
+  "metadata": {
+    "requiredEvidence": true,
+    "approver": "manager"
+  },
+  "order": 1,
+  "createdAt": "2024-03-20T10:00:00.000Z",
+  "updatedAt": "2024-03-20T10:00:00.000Z"
+}
+```
+
+## API Usage
+
+### Creating a Checklist Item Template with Order
+
+When creating a checklist item template, the `order` field is automatically calculated and set to the maximum order value for all checklist item templates in the same workflow template plus 1. This ensures that new checklist item templates are always added to the end of the list.
+
+```json
+{
+  "workflowTemplateId": "60d21bbfe3d5d533d9fc1e4d",
+  "name": "Upload Model Documentation",
+  "description": "Upload documentation for the AI model",
+  "type": "document",
+  "dependencies_requires": [],
+  "metadata": {
+    "requiredEvidence": true,
+    "approver": "manager"
+  }
+}
+```
+
+The response will include the automatically calculated `order` value:
+
+```json
+{
+  "_id": "60d21bbfe3d5d533d9fc1e4c",
+  "workflowTemplateId": "60d21bbfe3d5d533d9fc1e4d",
+  "name": "Upload Model Documentation",
+  "description": "Upload documentation for the AI model",
+  "type": "document",
+  "dependencies_requires": [],
+  "metadata": {
+    "requiredEvidence": true,
+    "approver": "manager"
+  },
+  "order": 3,
+  "createdAt": "2024-03-20T10:00:00.000Z",
+  "updatedAt": "2024-03-20T10:00:00.000Z"
+}
+```
+
+### Updating a Checklist Item Template's Order
+
+You can update the `order` field of an existing checklist item template:
+
+```json
+{
+  "order": 2
+}
+```
+
+### Deleting a Checklist Item Template
+
+When a checklist item template is deleted, all remaining checklist item templates in the same workflow template with a higher order value will have their order decremented by 1. This ensures that the order remains sequential without gaps.
+
+For example, if you have checklist item templates with orders 0, 1, 2, 3 and delete the template with order 1, the remaining templates will be reordered to 0, 1, 2.
+
+### Retrieving Checklist Item Templates
+
+When retrieving checklist item templates for a workflow template, they are automatically sorted by their `order` field:
+
+```
+GET /api/v1/checklist-item-templates?workflowTemplateId=60d21bbfe3d5d533d9fc1e4d
+```
+
+## Migration
+
+A migration script has been created to add the `order` field to existing checklist item templates and instances. The migration runs automatically when the application is deployed.
+
+For existing checklist item templates, the `order` is initially set based on the template's name (alphabetical order). For existing checklist item instances, the `order` is copied from their corresponding templates.
+
+## UI Considerations
+
+The UI should display checklist items in the order specified by the `order` field. This provides a consistent and predictable experience for users, regardless of when the checklist items were created or their alphabetical order.

--- a/scripts/manage-mongodb.js
+++ b/scripts/manage-mongodb.js
@@ -453,6 +453,7 @@ async function resetSchemaValidations() {
             items: { bsonType: 'objectId' }
           },
           metadata: { bsonType: 'object' },
+          order: { bsonType: 'int' },
           createdAt: { bsonType: 'date' },
           updatedAt: { bsonType: 'date' }
         }
@@ -488,6 +489,7 @@ async function resetSchemaValidations() {
             items: { bsonType: 'objectId' }
           },
           metadata: { bsonType: 'object' },
+          order: { bsonType: 'int' },
           createdAt: { bsonType: 'date' },
           updatedAt: { bsonType: 'date' }
         }

--- a/scripts/migrations/add-checklist-item-order.js
+++ b/scripts/migrations/add-checklist-item-order.js
@@ -1,0 +1,88 @@
+/**
+ * Migration script to add order field to existing checklist item templates
+ * @param {import('mongodb').Db} db - MongoDB database instance
+ * @param {object} logger - Logger instance
+ * @returns {Promise<void>}
+ */
+export default async function (db, logger) {
+  logger.info('Updating checklist item templates...')
+
+  // Get all workflow templates
+  const workflowTemplates = await db
+    .collection('workflowTemplates')
+    .find({})
+    .toArray()
+
+  for (const workflowTemplate of workflowTemplates) {
+    // Get all checklist item templates for this workflow template
+    const checklistItemTemplates = await db
+      .collection('checklistItemTemplates')
+      .find({ workflowTemplateId: workflowTemplate._id })
+      .sort({ name: 1 }) // Sort by name initially
+      .toArray()
+
+    // Update each checklist item template with an order field
+    for (let i = 0; i < checklistItemTemplates.length; i++) {
+      await db
+        .collection('checklistItemTemplates')
+        .updateOne(
+          { _id: checklistItemTemplates[i]._id },
+          { $set: { order: i } }
+        )
+      logger.info(
+        `Updated checklist item template ${checklistItemTemplates[i].name} with order ${i}`
+      )
+    }
+  }
+
+  // Update checklist item instances with order from their templates
+  logger.info('Updating checklist item instances...')
+
+  // Get all workflow instances
+  const workflowInstances = await db
+    .collection('workflowInstances')
+    .find({})
+    .toArray()
+
+  for (const workflowInstance of workflowInstances) {
+    // Get all checklist item instances for this workflow instance
+    const checklistItemInstances = await db
+      .collection('checklistItemInstances')
+      .find({ workflowInstanceId: workflowInstance._id })
+      .toArray()
+
+    // Create a map of checklist item template IDs to their order
+    const templateOrderMap = new Map()
+    const checklistItemTemplateIds = checklistItemInstances.map(
+      (ci) => ci.checklistItemTemplateId
+    )
+
+    if (checklistItemTemplateIds.length > 0) {
+      const checklistItemTemplates = await db
+        .collection('checklistItemTemplates')
+        .find({
+          _id: { $in: checklistItemTemplateIds }
+        })
+        .toArray()
+
+      checklistItemTemplates.forEach((template) => {
+        templateOrderMap.set(template._id.toString(), template.order || 0)
+      })
+
+      // Update each checklist item instance with the order from its template
+      for (const instance of checklistItemInstances) {
+        const templateOrder =
+          templateOrderMap.get(instance.checklistItemTemplateId.toString()) || 0
+
+        await db
+          .collection('checklistItemInstances')
+          .updateOne({ _id: instance._id }, { $set: { order: templateOrder } })
+        logger.info(
+          `Updated checklist item instance ${instance.name} with order ${templateOrder}`
+        )
+      }
+    }
+  }
+
+  logger.info('Migration completed successfully')
+}

--- a/src/api/checklist-item-instances/index.js
+++ b/src/api/checklist-item-instances/index.js
@@ -35,6 +35,11 @@ const baseChecklistItemSchema = Joi.object({
       completedDate: '2024-03-20T10:00:00.000Z'
     })
     .description('Additional configuration based on checklist item type'),
+  order: Joi.number()
+    .integer()
+    .min(0)
+    .example(1)
+    .description('Manual ordering position for the checklist item'),
   createdAt: Joi.date().example('2024-03-20T10:00:00.000Z'),
   updatedAt: Joi.date().example('2024-03-20T10:00:00.000Z')
 }).id('ChecklistItemInstance')

--- a/src/api/checklist-item-instances/model.js
+++ b/src/api/checklist-item-instances/model.js
@@ -11,6 +11,7 @@ import { ObjectId } from 'mongodb'
  * @property {string} status - Current status (e.g. 'incomplete', 'complete', 'not_required') (required)
  * @property {import('mongodb').ObjectId[]} dependencies_requires - Array of checklist item instance IDs that this item depends on
  * @property {object} [metadata] - Additional configuration
+ * @property {number} [order] - Manual ordering position for the checklist item
  * @property {Date} createdAt - When the instance was created (required)
  * @property {Date} updatedAt - When the instance was last updated (required)
  */
@@ -25,6 +26,7 @@ import { ObjectId } from 'mongodb'
  * @param {string} data.type - Type of checklist item
  * @param {string[]} [data.dependencies_requires] - Array of checklist item instance IDs that this item depends on
  * @param {object} [data.metadata] - Additional configuration
+ * @param {number} [data.order] - Manual ordering position for the checklist item
  * @returns {Omit<ChecklistItemInstance, '_id'>}
  */
 export function createChecklistItemInstance(data) {
@@ -46,6 +48,7 @@ export function createChecklistItemInstance(data) {
       typeof id === 'string' ? new ObjectId(id) : id
     ),
     metadata: data.metadata ?? {},
+    order: data.order ?? 0,
     createdAt: now,
     updatedAt: now
   }

--- a/src/api/checklist-item-instances/validation.js
+++ b/src/api/checklist-item-instances/validation.js
@@ -29,7 +29,8 @@ export const updateChecklistItemInstanceSchema = Joi.object({
   type: Joi.string().valid('approval', 'document', 'task'),
   status: Joi.string().valid('incomplete', 'complete', 'not_required'),
   metadata: Joi.object(),
-  dependencies_requires: Joi.array().items(objectIdSchema)
+  dependencies_requires: Joi.array().items(objectIdSchema),
+  order: Joi.number().integer().min(0)
 }).min(1)
 
 export const idSchema = Joi.object({

--- a/src/api/checklist-item-templates/model.js
+++ b/src/api/checklist-item-templates/model.js
@@ -9,6 +9,7 @@ import { ObjectId } from 'mongodb'
  * @property {string} type - Type of checklist item (e.g. 'approval', 'document', 'task') (required)
  * @property {import('mongodb').ObjectId[]} dependencies_requires - Array of checklist item template IDs that this item depends on
  * @property {object} [metadata] - Additional configuration
+ * @property {number} [order] - Manual ordering position for the checklist item
  * @property {Date} createdAt - When the template was created (required)
  * @property {Date} updatedAt - When the template was last updated (required)
  */
@@ -22,6 +23,7 @@ import { ObjectId } from 'mongodb'
  * @param {string} [data.description] - Detailed description
  * @param {string[]} [data.dependencies_requires] - Array of checklist item template IDs that this item depends on
  * @param {object} [data.metadata] - Additional configuration
+ * @param {number} data.order - Manual ordering position for the checklist item
  * @returns {Omit<ChecklistItemTemplate, '_id'>}
  */
 export function createChecklistItemTemplate(data) {
@@ -38,6 +40,7 @@ export function createChecklistItemTemplate(data) {
       typeof id === 'string' ? new ObjectId(id) : id
     ),
     metadata: data.metadata ?? {},
+    order: data.order,
     createdAt: now,
     updatedAt: now
   }

--- a/src/api/checklist-item-templates/validation.js
+++ b/src/api/checklist-item-templates/validation.js
@@ -23,7 +23,8 @@ export const updateChecklistItemTemplateSchema = Joi.object({
   description: Joi.string().allow(''),
   type: Joi.string().valid('approval', 'document', 'task'),
   dependencies_requires: Joi.array().items(objectIdSchema),
-  metadata: Joi.object()
+  metadata: Joi.object(),
+  order: Joi.number().integer().min(0)
 }).min(1)
 
 export const idSchema = Joi.object({

--- a/src/api/common/helpers/mongodb.js
+++ b/src/api/common/helpers/mongodb.js
@@ -206,6 +206,7 @@ async function createSchemaValidations(db) {
             items: { bsonType: 'objectId' }
           },
           metadata: { bsonType: 'object' },
+          order: { bsonType: 'int' },
           createdAt: { bsonType: 'date' },
           updatedAt: { bsonType: 'date' }
         }
@@ -241,6 +242,7 @@ async function createSchemaValidations(db) {
             items: { bsonType: 'objectId' }
           },
           metadata: { bsonType: 'object' },
+          order: { bsonType: 'int' },
           createdAt: { bsonType: 'date' },
           updatedAt: { bsonType: 'date' }
         }

--- a/src/api/projects/controller.js
+++ b/src/api/projects/controller.js
@@ -43,6 +43,7 @@ async function createAllChecklistItemInstances(
       status: 'incomplete',
       dependencies_requires: [], // Will be populated in second phase
       metadata: template.metadata || {},
+      order: template.order || 0,
       createdAt: new Date(),
       updatedAt: new Date()
     }

--- a/tests/api/checklist-item-templates.spec.js
+++ b/tests/api/checklist-item-templates.spec.js
@@ -545,4 +545,257 @@ test.describe('Checklist Item Template API', () => {
     // Clean up
     await request.delete(`/api/v1/checklist-item-templates/${template._id}`)
   })
+
+  test('should reorder checklist item templates after deletion', async ({
+    request
+  }) => {
+    // Create three more checklist item templates with sequential order
+    const checklistData1 = {
+      name: `Test Checklist Item Template 1 ${uniqueId}`,
+      description: 'Test checklist item template 1',
+      type: 'approval',
+      workflowTemplateId
+    }
+    const checklistData2 = {
+      name: `Test Checklist Item Template 2 ${uniqueId}`,
+      description: 'Test checklist item template 2',
+      type: 'approval',
+      workflowTemplateId
+    }
+    const checklistData3 = {
+      name: `Test Checklist Item Template 3 ${uniqueId}`,
+      description: 'Test checklist item template 3',
+      type: 'approval',
+      workflowTemplateId
+    }
+
+    // Create the checklist item templates
+    const response1 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData1
+    })
+    const data1 = await response1.json()
+    const checklistId1 = data1._id
+    const order1 = data1.order
+
+    const response2 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData2
+    })
+    const data2 = await response2.json()
+    const checklistId2 = data2._id
+    const order2 = data2.order
+
+    const response3 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData3
+    })
+    const data3 = await response3.json()
+    const checklistId3 = data3._id
+    const order3 = data3.order
+
+    // Verify the initial orders are sequential
+    expect(order2).toBe(order1 + 1)
+    expect(order3).toBe(order2 + 1)
+
+    // Delete the middle checklist item template
+    const deleteResponse = await request.delete(
+      `/api/v1/checklist-item-templates/${checklistId2}`
+    )
+    expect(deleteResponse.ok()).toBeTruthy()
+
+    // Verify the first checklist item template's order remains unchanged
+    const getResponse1 = await request.get(
+      `/api/v1/checklist-item-templates/${checklistId1}`
+    )
+    const updatedData1 = await getResponse1.json()
+    expect(updatedData1.order).toBe(order1)
+
+    // Verify the third checklist item template's order has been decremented
+    const getResponse3 = await request.get(
+      `/api/v1/checklist-item-templates/${checklistId3}`
+    )
+    const updatedData3 = await getResponse3.json()
+    expect(updatedData3.order).toBe(order3 - 1)
+
+    // Clean up
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId1}`)
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId3}`)
+  })
+
+  test('should reorder checklist item templates when updating order', async ({
+    request
+  }) => {
+    // Create three checklist item templates with sequential order
+    const checklistData1 = {
+      name: `Test Checklist Item Template 1 ${uniqueId}`,
+      description: 'Test checklist item template 1',
+      type: 'approval',
+      workflowTemplateId
+    }
+    const checklistData2 = {
+      name: `Test Checklist Item Template 2 ${uniqueId}`,
+      description: 'Test checklist item template 2',
+      type: 'approval',
+      workflowTemplateId
+    }
+    const checklistData3 = {
+      name: `Test Checklist Item Template 3 ${uniqueId}`,
+      description: 'Test checklist item template 3',
+      type: 'approval',
+      workflowTemplateId
+    }
+
+    // Create the checklist item templates
+    const response1 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData1
+    })
+    const data1 = await response1.json()
+    const checklistId1 = data1._id
+    const order1 = data1.order
+
+    const response2 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData2
+    })
+    const data2 = await response2.json()
+    const checklistId2 = data2._id
+    const order2 = data2.order
+
+    const response3 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData3
+    })
+    const data3 = await response3.json()
+    const checklistId3 = data3._id
+    const order3 = data3.order
+
+    // Verify the initial orders are sequential
+    expect(order2).toBe(order1 + 1)
+    expect(order3).toBe(order2 + 1)
+
+    // Move the first checklist item template to the end (order 2)
+    const updateResponse = await request.put(
+      `/api/v1/checklist-item-templates/${checklistId1}`,
+      {
+        data: { order: order3 }
+      }
+    )
+    expect(updateResponse.ok()).toBeTruthy()
+
+    // Verify the updated order of the first checklist item template
+    const getResponse1 = await request.get(
+      `/api/v1/checklist-item-templates/${checklistId1}`
+    )
+    const updatedData1 = await getResponse1.json()
+    expect(updatedData1.order).toBe(order3)
+
+    // Verify the second checklist item template's order has been decremented
+    const getResponse2 = await request.get(
+      `/api/v1/checklist-item-templates/${checklistId2}`
+    )
+    const updatedData2 = await getResponse2.json()
+    expect(updatedData2.order).toBe(order2 - 1)
+
+    // Verify the third checklist item template's order has been decremented
+    const getResponse3 = await request.get(
+      `/api/v1/checklist-item-templates/${checklistId3}`
+    )
+    const updatedData3 = await getResponse3.json()
+    expect(updatedData3.order).toBe(order3 - 1)
+
+    // Clean up
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId1}`)
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId2}`)
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId3}`)
+  })
+
+  test('should return checklist item templates in order when filtering by workflowTemplateId', async ({
+    request
+  }) => {
+    // Create three checklist item templates with different orders
+    const orderTestUniqueId = getUniqueId()
+
+    // Create checklist item templates with specific orders
+    const checklistData1 = {
+      name: `Order Test Checklist 1 ${orderTestUniqueId}`,
+      description: 'First checklist for order test',
+      type: 'approval',
+      workflowTemplateId
+    }
+    const checklistData2 = {
+      name: `Order Test Checklist 2 ${orderTestUniqueId}`,
+      description: 'Second checklist for order test',
+      type: 'approval',
+      workflowTemplateId
+    }
+    const checklistData3 = {
+      name: `Order Test Checklist 3 ${orderTestUniqueId}`,
+      description: 'Third checklist for order test',
+      type: 'approval',
+      workflowTemplateId
+    }
+
+    // Create the checklist item templates
+    const response1 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData1
+    })
+    const data1 = await response1.json()
+    const checklistId1 = data1._id
+    const order1 = data1.order
+
+    const response2 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData2
+    })
+    const data2 = await response2.json()
+    const checklistId2 = data2._id
+    const order2 = data2.order
+
+    const response3 = await request.post('/api/v1/checklist-item-templates', {
+      data: checklistData3
+    })
+    const data3 = await response3.json()
+    const checklistId3 = data3._id
+    const order3 = data3.order
+
+    // Verify the initial orders are sequential
+    expect(order2).toBe(order1 + 1)
+    expect(order3).toBe(order2 + 1)
+
+    // Reorder the templates: move the third template to the beginning
+    await request.put(`/api/v1/checklist-item-templates/${checklistId3}`, {
+      data: { order: 0 }
+    })
+
+    // Get all checklist item templates filtered by workflowTemplateId
+    const filterResponse = await request.get(
+      `/api/v1/checklist-item-templates?workflowTemplateId=${workflowTemplateId}`
+    )
+    expect(filterResponse.ok()).toBeTruthy()
+    const filteredData = await filterResponse.json()
+
+    // Find our test templates in the filtered results
+    const testTemplates = filteredData.filter(
+      (template) =>
+        template._id === checklistId1 ||
+        template._id === checklistId2 ||
+        template._id === checklistId3
+    )
+
+    // Verify they are sorted by order
+    for (let i = 1; i < testTemplates.length; i++) {
+      expect(testTemplates[i - 1].order).toBeLessThanOrEqual(
+        testTemplates[i].order
+      )
+    }
+
+    // Verify the third template is now first in our test templates
+    const sortedIds = testTemplates.map((t) => t._id)
+    expect(sortedIds.indexOf(checklistId3)).toBeLessThan(
+      sortedIds.indexOf(checklistId1)
+    )
+    expect(sortedIds.indexOf(checklistId3)).toBeLessThan(
+      sortedIds.indexOf(checklistId2)
+    )
+
+    // Clean up the test checklist item templates
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId1}`)
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId2}`)
+    await request.delete(`/api/v1/checklist-item-templates/${checklistId3}`)
+  })
 })


### PR DESCRIPTION
- Introduce `order` field to checklist item templates and instances
- Implement automatic order calculation during creation
- Add reordering logic when updating or deleting checklist item templates
- Update sorting to prioritize order field in API responses
- Modify schema validations to include order field
- Add comprehensive test cases to verify reordering behavior